### PR TITLE
Use quieter ARC compatibility macros

### DIFF
--- a/DCTConnectionController.h
+++ b/DCTConnectionController.h
@@ -36,6 +36,10 @@
 
 #import <Availability.h>
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_4_3
+    #warning "This library uses ARC which is only available in iOS SDK 4.3 and later."
+#endif
+
 #if !defined dct_weak && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_5_0
 	#define dct_weak weak
 	#define __dct_weak __weak
@@ -44,8 +48,6 @@
 	#define dct_weak unsafe_unretained
 	#define __dct_weak __unsafe_unretained
 	#define dct_nil(x) x = nil
-#else
-	#warning "This library uses ARC which is only available in iOS SDK 4.3 and later."
 #endif
 
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
The way it was originally written - once `dct_weak` was defined it would drop through to the #warning.
